### PR TITLE
Fix definition of email type in node

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This will validate email, correctly:
 
 ```
 var mongoose = require('mongoose');
-require('mongoose-type-email');
+require('mongoose-type-email')(mongoose);
 
 var UserSchema = new mongoose.Schema({
     email: {

--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
-var mongoose = require('mongoose');
-
-function Email (path, options) {
-	mongoose.SchemaTypes.String.call(this, path, options);
-	function validateEmail (val) {
-		// http://www.w3.org/TR/html5/forms.html#valid-e-mail-address
-		return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(val);
+module.exports = function(mongoose) {
+	function Email (path, options) {
+		mongoose.SchemaTypes.String.call(this, path, options);
+		function validateEmail (val) {
+			// http://www.w3.org/TR/html5/forms.html#valid-e-mail-address
+			return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(val);
+		}
+		this.validate(validateEmail, 'invalid email address');
 	}
-	this.validate(validateEmail, 'invalid email address');
-}
 
-Email.prototype.__proto__ = mongoose.SchemaTypes.String.prototype;
+	Email.prototype.__proto__ = mongoose.SchemaTypes.String.prototype;
 
-Email.prototype.cast = function (val) {
-	return val.toLowerCase();
+	Email.prototype.cast = function (val) {
+		return val.toLowerCase();
+	};
+
+	mongoose.SchemaTypes.Email = Email;
+	mongoose.Types.Email = String;
 };
-
-mongoose.SchemaTypes.Email = module.exports = Email;
-mongoose.Types.Email = String;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-type-email",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "An email field-type for Mongoose schemas",
   "main": "index.js",
   "scripts": {
@@ -25,9 +25,7 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "mocha": "^2.1.0",
-    "mockgoose": "^1.10.7"
-  },
-  "dependencies": {
+    "mockgoose": "^1.10.7",
     "mongoose": "^3.8.x"
   }
 }

--- a/test/mongoose-type-email.js
+++ b/test/mongoose-type-email.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 var mongoose = require('mongoose');
-require('../');
+require('../')(mongoose);
 
 require('mockgoose')(mongoose);
 


### PR DESCRIPTION
The included mongoose version may be different from the one included by
an application. This results in a definition of schema types on the
internal mongoose module.

Fix this by explicitly letting the user inject a mongoose module which
has also the advantage of dropping a dependency. As this breaks
backwards compatibility, bump the major version.

Tested with mongoose 3.9.7 and 4.0.3.

---

The diff looks huge, but it is mostly whitespace due to reindent. Here is a `git diff -U1 -w f71fa18~..f71fa18`:

``` diff
diff --git a/README.md b/README.md
index 3074024..392fb2d 100644
--- a/README.md
+++ b/README.md
@@ -14,3 +14,3 @@ This will validate email, correctly:
 var mongoose = require('mongoose');
-require('mongoose-type-email');
+require('mongoose-type-email')(mongoose);

diff --git a/index.js b/index.js
index f63a77a..e735b33 100644
--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-var mongoose = require('mongoose');
-
+module.exports = function(mongoose) {
    function Email (path, options) {
@@ -17,3 +16,4 @@ Email.prototype.cast = function (val) {

-mongoose.SchemaTypes.Email = module.exports = Email;
+   mongoose.SchemaTypes.Email = Email;
    mongoose.Types.Email = String;
+};
diff --git a/package.json b/package.json
index 5da7430..1690dc2 100644
--- a/package.json
+++ b/package.json
@@ -2,3 +2,3 @@
   "name": "mongoose-type-email",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "An email field-type for Mongoose schemas",
@@ -27,5 +27,3 @@
     "mocha": "^2.1.0",
-    "mockgoose": "^1.10.7"
-  },
-  "dependencies": {
+    "mockgoose": "^1.10.7",
     "mongoose": "^3.8.x"
diff --git a/test/mongoose-type-email.js b/test/mongoose-type-email.js
index 54e5477..b815539 100644
--- a/test/mongoose-type-email.js
+++ b/test/mongoose-type-email.js
@@ -2,3 +2,3 @@ var expect = require('chai').expect;
 var mongoose = require('mongoose');
-require('../');
+require('../')(mongoose);

```
