### PR TITLE
Update to latest mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "mocha": "^2.1.0",
-    "mockgoose": "^1.10.7"
+    "mockgoose": "^1.10.7",
+    "mongoose": "^4.3.5"
   },
-  "dependencies": {
-    "mongoose": "^3.8.x"
+  "peerDependencies": {
+    "mongoose": "^4.3.5"
   }
 }


### PR DESCRIPTION
Hello David,
Please take a look on this PR. I have a problem with using your package this latest mongoose. The problem is that this package is directly depending on mongoose. So if the parent package is using different version of mongoose npm will install separate mongoose for this package causing no change in the parents mongoose schema types. That's why I changed the dependency to peer dependency.

Thanks
Igor
