### PR TITLE
allow custom message for email validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Email (path, options) {
 		// http://www.w3.org/TR/html5/forms.html#valid-e-mail-address
 		return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(val);
 	}
-	this.validate(validateEmail, 'invalid email address');
+	this.validate(validateEmail, options.message || 'invalid email address');
 }
 
 Email.prototype.__proto__ = mongoose.SchemaTypes.String.prototype;

--- a/test/mongoose-type-email.js
+++ b/test/mongoose-type-email.js
@@ -26,6 +26,10 @@ var UserNested = mongoose.model('UserNested', new mongoose.Schema({
 	}
 }));
 
+var UserCustomMessage = mongoose.model('UserCustomMessage', new mongoose.Schema({
+	email: { type: mongoose.SchemaTypes.Email, message: 'error.email' }
+}));
+
 describe('mongoose-type-email', function(){
 	before(function(done){
 		this.timeout(0)
@@ -81,6 +85,15 @@ describe('mongoose-type-email', function(){
 		user.validate(function(err){
 			expect(err.errors['email.home'].message).to.equal('Path `email.home` is required.');
 			expect(err.errors['email.work'].message).to.equal('Path `email.work` is required.');
+			done();
+		});
+	});
+
+	it('should not enable blank value with custom message', function(done){
+		var user =  new UserCustomMessage();
+		user.email = '';
+		user.validate(function(err){
+			expect(err.errors.email.message).to.equal('error.email');
 			done();
 		});
 	});


### PR DESCRIPTION
In order to unify error management on our system, we need a unified approach for the error message.

Here is a way to override default message with a custom one :

```
var UserCustomMessage = mongoose.model('UserCustomMessage', new mongoose.Schema({
	email: { type: mongoose.SchemaTypes.Email, message: 'my.custom.error.message' }
}));
```