### PR TITLE
Use * instead of empty string for peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "jest": "^22.4.4"
   },
   "peerDependencies": {
-    "mongoose": ""
+    "mongoose": "*"
   }
 }


### PR DESCRIPTION
Thanks for maintaining this module @konsumer :+1: :taco: 

I have read the discussion in #3 and even though an empty string is documented as equivalent to `*`, I was still getting this error when running `npm list` in my project using npm version `5.6.0`

```
[...]
-- UNMET PEER DEPENDENCY mongoose@5.3.14                                                                    
| +-- async@2.6.1                                                                                            
| | `-- lodash@4.17.11                                                                                       
| +-- bson@1.1.0                                                                                             
| +-- kareem@2.3.0                                                                                           
| +-- lodash.get@4.4.2                                                                                       
| +-- mongodb@3.1.10                                                                                         
| | +-- mongodb-core@3.1.9 deduped                                                                           
| | `-- safe-buffer@5.1.2                                                                                    
| +-- mongodb-core@3.1.9                                                                                     
| | +-- bson@1.1.0 deduped                                                                                   
| | +-- require_optional@1.0.1                                                                               
| | | +-- resolve-from@2.0.0                                                                                 
| | | `-- semver@5.5.0 deduped                                                                               
| | +-- safe-buffer@5.1.2                                                                                    
| | `-- saslprep@1.0.2
| |   `-- sparse-bitfield@3.0.3
| |     `-- memory-pager@1.1.0
| +-- mongoose-legacy-pluralize@1.0.2
| +-- mpath@0.5.1
| +-- mquery@3.2.0
| | +-- bluebird@3.5.1
| | +-- debug@3.1.0
| | | `-- ms@2.0.0 deduped
| | +-- regexp-clone@0.0.1 deduped
| | +-- safe-buffer@5.1.2
| | `-- sliced@1.0.1 deduped
| +-- ms@2.0.0
| +-- regexp-clone@0.0.1
| +-- safe-buffer@5.1.2
| `-- sliced@1.0.1
+-- mongoose-type-email@1.0.9
+-- node-dogstatsd@0.0.7
+-- prettier@1.12.1
`-- uuid@3.2.1

npm ERR! peer dep missing: mongoose@, required by mongoose-type-email@1.0.9
[...]
```

Updating this module's `package.json` directly inside `node_modules` fixed the error. 

Even though the two formats _should_ be equivalent, and the app works just fine, I thought this change was harmless and quick enough to submit it. I hope you find it useful.