### PR TITLE
 Add Needed SchemaType Methods for mongoose 5.4+

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ function validateEmail (val, options) {
 }
 
 function Email (path, options) {
+  this.options = options;
+  this.path = path;
   mongoose.SchemaTypes.String.call(this, path, options)
   this.validate(function (val) { return validateEmail(val, options) }, options.message || 'invalid email address')
 }
@@ -22,6 +24,14 @@ Object.setPrototypeOf(Email.prototype, mongoose.SchemaTypes.String.prototype)
 Email.prototype.cast = function (val) {
   return val.toLowerCase()
 }
+
+Email.prototype.get = function (val) {
+    return val.toLowerCase()
+}
+
+Email.prototype.checkRequired = function (val) {
+    return typeof val === 'string' && validateEmail(val, this.options);
+};
 
 mongoose.SchemaTypes.Email = module.exports = Email
 mongoose.Types.Email = String


### PR DESCRIPTION
After mongoose 5.4, SchemaTypes need three methods (`cast()`, `get()` and `checkRequired()`) to work.
more info:
http://thecodebarbarian.com/whats-new-in-mongoose-54-global-schematype-configuration.html
https://mongoosejs.com/docs/api.html#schematype_SchemaType-checkRequired